### PR TITLE
Fix error message count is too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ publish dummy json data like `{"message": "dummy", "value": 0}\n{"message": "dum
   key <YOUR KEY>
   flush_interval 10
   autocreate_topic false
+  max_messages 1000
 </match>
 ```
 
 - `autocreate_topic` (optional, default: `false`)
   - If set to `true`, specified topic will be created when it doesn't exist.
+- `max_messages` (optional, default: `1000`)
+  - Publishing messages per request to Cloud Pub/Sub. ref: https://cloud.google.com/pubsub/quotas#other_limits
 
 ## Pull messages
 Use `in_gcloud_pubsub`.

--- a/test/plugin/test_out_gcloud_pubsub.rb
+++ b/test/plugin/test_out_gcloud_pubsub.rb
@@ -33,6 +33,7 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
     assert_equal('key-test', d.instance.key)
     assert_equal(false, d.instance.autocreate_topic)
     assert_equal(1, d.instance.flush_interval)
+    assert_equal(1000, d.instance.max_messages)
   end
 
   def test_autocreate_topic
@@ -59,12 +60,36 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
     d.instance.start()
   end
 
+  def test_max_messages
+    d = create_driver(DEFAULT_CONFIG)
+
+    client = mock!
+    client.name.times(2) { 'topic-test' }
+    client.publish.times(2)
+
+    pubsub_mock = mock!.topic(anything, anything) { client }
+    gcloud_mock = mock!.pubsub { pubsub_mock }
+    stub(Gcloud).new { gcloud_mock }
+
+    time = Time.parse("2016-07-09 11:12:13 UTC").to_i
+
+    # max_messages is default 1000
+    1001.times do |i|
+      d.emit({"a" => i}, time)
+    end
+
+    d.run
+  end
+
   def test_re_raise_errors
     d = create_driver(DEFAULT_CONFIG)
     chunk = Fluent::MemoryBufferChunk.new('key', 'data')
     client = Object.new
     def client.publish
       raise ReRaisedError
+    end
+    def client.name
+      'test-topic'
     end
     d.instance.instance_variable_set(:@client, client)
 


### PR DESCRIPTION
Fix error `message_count is too large`.
It's due to Fluentd's API limitation. Please see tagomoris/fluent-plugin-buffer-lightening#6 .

This PR will also enable to use file or memory buffer plugin instead of lightning buffer in fluent.conf.
