### PR TITLE
Fix buffer chunk encoding compatibility problem between v0.12 and v0.14

### DIFF
--- a/fluent-plugin-gcloud-pubsub.gemspec
+++ b/fluent-plugin-gcloud-pubsub.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency "fluentd", [">= 0.10.58", "< 2"]
+  gem.add_runtime_dependency "yajl-ruby", "~> 1.0"
   gem.add_runtime_dependency "activesupport", "= 4.2.7.1"
   gem.add_runtime_dependency "gcloud", "= 0.6.3"
   gem.add_runtime_dependency "fluent-plugin-buffer-lightening", ">= 0.0.2"

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -1,5 +1,6 @@
 require 'gcloud'
 require 'fluent/output'
+require 'yajl'
 
 module Fluent
   class GcloudPubSubOutput < BufferedOutput
@@ -47,7 +48,7 @@ module Fluent
       messages = []
 
       chunk.msgpack_each do |tag, time, record|
-        messages << record.to_json
+        messages << Yajl.dump(record)
       end
 
       if messages.length > 0

--- a/test/plugin/test_out_gcloud_pubsub.rb
+++ b/test/plugin/test_out_gcloud_pubsub.rb
@@ -80,6 +80,24 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
     d.run
   end
 
+  def test_encoded_multibyte_strings
+    # on fluentd v0.14, all strings treated as "ASCII-8BIT" except specified encoding.
+    d = create_driver(DEFAULT_CONFIG)
+
+    client = mock!
+    client.name.once { 'topic-test' }
+    client.publish.once
+
+    pubsub_mock = mock!.topic(anything, anything) { client }
+    gcloud_mock = mock!.pubsub { pubsub_mock }
+    stub(Gcloud).new { gcloud_mock }
+
+    time = Time.parse("2016-07-09 11:12:13 UTC").to_i
+
+    d.emit({"a" => "あああ".force_encoding("ASCII-8BIT")}, time)
+    d.run
+  end
+
   def test_re_raise_errors
     d = create_driver(DEFAULT_CONFIG)
     client = Object.new


### PR DESCRIPTION
See: https://github.com/fluent/fluentd/issues/1106
