### PR TITLE
Remove lightening buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ publish dummy json data like `{"message": "dummy", "value": 0}\n{"message": "dum
   topic <YOUR TOPIC>
   key <YOUR KEY>
   flush_interval 10
+  try_flush_interval 1
   autocreate_topic false
   max_messages 1000
 </match>

--- a/fluent-plugin-gcloud-pubsub.gemspec
+++ b/fluent-plugin-gcloud-pubsub.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "yajl-ruby", "~> 1.0"
   gem.add_runtime_dependency "activesupport", "= 4.2.7.1"
   gem.add_runtime_dependency "gcloud", "= 0.6.3"
-  gem.add_runtime_dependency "fluent-plugin-buffer-lightening", ">= 0.0.2"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -6,13 +6,6 @@ module Fluent
   class GcloudPubSubOutput < BufferedOutput
     Fluent::Plugin.register_output('gcloud_pubsub', self)
 
-    config_set_default :buffer_type,                'lightening'
-    config_set_default :flush_interval,             1
-    config_set_default :try_flush_interval,         0.05
-    config_set_default :buffer_chunk_records_limit, 900
-    config_set_default :buffer_chunk_limit,         9437184
-    config_set_default :buffer_queue_limit,         64
-
     config_param :project,            :string,  :default => nil
     config_param :topic,              :string,  :default => nil
     config_param :key,                :string,  :default => nil


### PR DESCRIPTION
`lightening` buffer is not necessary for this plugin because of splitting messages in the plugin (https://github.com/mia-0032/fluent-plugin-gcloud-pubsub/pull/1).
