### PR TITLE
Bump up gcloud ruby to 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 1.9.3
   - 2.0
   - 2.1
   - 2.2.5
@@ -24,11 +23,8 @@ sudo: false
 
 matrix:
   allow_failures:
-    - rvm: 1.9.3
     - rvm: ruby-head
     - rvm: rbx
   exclude:
-    - rvm: 1.9.3
-      gemfile: Gemfile
     - rvm: 2.0
       gemfile: Gemfile

--- a/fluent-plugin-gcloud-pubsub.gemspec
+++ b/fluent-plugin-gcloud-pubsub.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "fluentd", [">= 0.10.58", "< 2"]
   gem.add_runtime_dependency "yajl-ruby", "~> 1.0"
-  gem.add_runtime_dependency "activesupport", "= 4.2.7.1"
-  gem.add_runtime_dependency "gcloud", "= 0.6.3"
+  gem.add_runtime_dependency "gcloud", "~> 0.12"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"

--- a/lib/fluent/plugin/gcloud_pubsub/client.rb
+++ b/lib/fluent/plugin/gcloud_pubsub/client.rb
@@ -9,7 +9,7 @@ module Fluent
         pubsub = (Gcloud.new project, key).pubsub
 
         @client = pubsub.topic topic, autocreate: autocreate_topic
-        raise Fluent::GcloudPubSub::Error "topic:#{topic} does not exist." if @client.nil?
+        raise Fluent::GcloudPubSub::Error.new "topic:#{topic} does not exist." if @client.nil?
       end
 
       def publish(messages)
@@ -25,15 +25,15 @@ module Fluent
       def initialize(project, key, topic, subscription)
         pubsub = (Gcloud.new project, key).pubsub
         @client = pubsub.subscription subscription
-        raise Fluent::GcloudPubSub::Error "subscription:#{subscription} does not exist." if @client.nil?
+        raise Fluent::GcloudPubSub::Error.new "subscription:#{subscription} does not exist." if @client.nil?
       end
 
       def pull(immediate, max)
-        @client.pull(immediate, max)
+        @client.pull immediate: immediate, max: max
       end
 
       def acknowledge(messages)
-        @client.acknowledge(messages)
+        @client.acknowledge messages
       end
     end
   end

--- a/lib/fluent/plugin/gcloud_pubsub/client.rb
+++ b/lib/fluent/plugin/gcloud_pubsub/client.rb
@@ -20,5 +20,21 @@ module Fluent
         end
       end
     end
+
+    class Subscriber
+      def initialize(project, key, topic, subscription)
+        pubsub = (Gcloud.new project, key).pubsub
+        @client = pubsub.subscription subscription
+        raise Fluent::GcloudPubSub::Error "subscription:#{subscription} does not exist." if @client.nil?
+      end
+
+      def pull(immediate, max)
+        @client.pull(immediate, max)
+      end
+
+      def acknowledge(messages)
+        @client.acknowledge(messages)
+      end
+    end
   end
 end

--- a/lib/fluent/plugin/gcloud_pubsub/client.rb
+++ b/lib/fluent/plugin/gcloud_pubsub/client.rb
@@ -1,0 +1,24 @@
+require 'gcloud'
+
+module Fluent
+  module GcloudPubSub
+    class Error < StandardError; end
+
+    class Publisher
+      def initialize(project, key, topic, autocreate_topic)
+        pubsub = (Gcloud.new project, key).pubsub
+
+        @client = pubsub.topic topic, autocreate: autocreate_topic
+        raise Fluent::GcloudPubSub::Error "topic:#{topic} does not exist." if @client.nil?
+      end
+
+      def publish(messages)
+        @client.publish do |batch|
+          messages.each do |m|
+            batch.publish m
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/in_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/in_gcloud_pubsub.rb
@@ -32,6 +32,7 @@ module Fluent
     def start
       super
       @subscriber = Fluent::GcloudPubSub::Subscriber.new @project, @key, @topic, @subscription
+      log.debug "connected subscription:#{@subscription} in project #{@project}"
       @stop_subscribing = false
       @subscribe_thread = Thread.new(&method(:subscribe))
     end

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -29,6 +29,7 @@ module Fluent
     def start
       super
       @publisher = Fluent::GcloudPubSub::Publisher.new @project, @key, @topic, @autocreate_topic
+      log.debug "connected topic:#{@topic} in project #{@project}"
     end
 
     def format(tag, time, record)

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -1,14 +1,15 @@
-require 'gcloud'
 require 'fluent/output'
 require 'yajl'
+
+require 'fluent/plugin/gcloud_pubsub/client'
 
 module Fluent
   class GcloudPubSubOutput < BufferedOutput
     Fluent::Plugin.register_output('gcloud_pubsub', self)
 
     config_param :project,            :string,  :default => nil
-    config_param :topic,              :string,  :default => nil
     config_param :key,                :string,  :default => nil
+    config_param :topic,              :string
     config_param :autocreate_topic,   :bool,    :default => false
     config_param :max_messages,       :integer, :default => 1000
     config_param :max_total_size,     :integer, :default => 10000000  # 10MB
@@ -23,15 +24,11 @@ module Fluent
 
     def configure(conf)
       super
-
-      raise Fluent::ConfigError, "'topic' must be specified." unless @topic
     end
 
     def start
       super
-
-      pubsub = (Gcloud.new @project, @key).pubsub
-      @client = pubsub.topic @topic, autocreate: @autocreate_topic
+      @publisher = Fluent::GcloudPubSub::Publisher.new @project, @key, @topic, @autocreate_topic
     end
 
     def format(tag, time, record)
@@ -62,13 +59,10 @@ module Fluent
       raise e
     end
 
+    private
     def publish(messages)
-      log.debug "send message topic:#{@client.name} length:#{messages.length.to_s}"
-      @client.publish do |batch|
-        messages.each do |m|
-          batch.publish m
-        end
-      end
+      log.debug "send message topic:#{@topic} length:#{messages.length.to_s}"
+      @publisher.publish messages
     end
   end
 end

--- a/test/plugin/test_in_gcloud_pubsub.rb
+++ b/test/plugin/test_in_gcloud_pubsub.rb
@@ -1,35 +1,52 @@
 require_relative "../test_helper"
 
-
 class GcloudPubSubInputTest < Test::Unit::TestCase
-  def setup
-    Fluent::Test.setup
-  end
+  CONFIG = %[
+      tag test
+      project project-test
+      subscription subscription-test
+      key key-test
+      format json
+  ]
 
   def create_driver(conf=CONFIG)
     Fluent::Test::InputTestDriver.new(Fluent::GcloudPubSubInput).configure(conf)
   end
 
-  def test_configure
-    d = create_driver(<<-EOC)
-      type gcloud_pubsub
-      tag test
-      project project-test
-      topic topic-test
-      subscription subscription-test
-      key key-test
-      max_messages 1000
-      return_immediately true
-      pull_interval 2
-      format json
-    EOC
+  setup do
+    Fluent::Test.setup
+  end
 
-    assert_equal('test', d.instance.tag)
-    assert_equal('project-test', d.instance.project)
-    assert_equal('topic-test', d.instance.topic)
-    assert_equal('subscription-test', d.instance.subscription)
-    assert_equal('key-test', d.instance.key)
-    assert_equal(1000, d.instance.max_messages)
-    assert_equal(true, d.instance.return_immediately)
+  sub_test_case 'configure' do
+    test 'all params are configured' do
+      d = create_driver(%[
+        tag test
+        project project-test
+        topic topic-test
+        subscription subscription-test
+        key key-test
+        max_messages 1000
+        return_immediately true
+        pull_interval 2
+        format json
+      ])
+
+      assert_equal('test', d.instance.tag)
+      assert_equal('project-test', d.instance.project)
+      assert_equal('topic-test', d.instance.topic)
+      assert_equal('subscription-test', d.instance.subscription)
+      assert_equal('key-test', d.instance.key)
+      assert_equal(2, d.instance.pull_interval)
+      assert_equal(1000, d.instance.max_messages)
+      assert_equal(true, d.instance.return_immediately)
+    end
+
+    test 'default values are configured' do
+      d = create_driver
+      assert_equal(nil, d.instance.topic)
+      assert_equal(5, d.instance.pull_interval)
+      assert_equal(100, d.instance.max_messages)
+      assert_equal(true, d.instance.return_immediately)
+    end
   end
 end


### PR DESCRIPTION
## Changed
- Remove ruby 1.9.3 because `gcloud-ruby` support ruby version above 2.0.0
- Bump up `gcloud-ruby` to 0.12
- Refactor `out_gcloud_pubsub`, `in_gcloud_pubsub`
- Update README
