### PR TITLE
Change default max message size and add debug log

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Use `gcloud_pubsub` output plugin.
 - `max_messages` (optional, default: `1000`)
   - Publishing messages count per request to Cloud Pub/Sub.
     - See https://cloud.google.com/pubsub/quotas#other_limits
-- `max_total_size` (optional, default: `10000000` = `10MB`)
-  - Publishing messages bytesize per request to Cloud Pub/Sub.
+- `max_total_size` (optional, default: `9800000` = `9.8MB`)
+  - Publishing messages bytesize per request to Cloud Pub/Sub. This parameter affects only message size. You should specify a little smaller value than quota.
     - See https://cloud.google.com/pubsub/quotas#other_limits
 - `buffer_type`, `buffer_path`, `flush_interval`, `try_flush_interval`
   - These are fluentd buffer configuration. See http://docs.fluentd.org/articles/buffer-plugin-overview

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -65,7 +65,7 @@ module Fluent
     private
 
     def publish(messages)
-      log.debug "send message topic:#{@topic} length:#{messages.length.to_s}"
+      log.debug "send message topic:#{@topic} length:#{messages.length} size:#{messages.map(&:bytesize).inject(:+)}"
       @publisher.publish messages
     end
   end

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -11,7 +11,7 @@ module Fluent
     config_param :topic,              :string
     config_param :autocreate_topic,   :bool,    :default => false
     config_param :max_messages,       :integer, :default => 1000
-    config_param :max_total_size,     :integer, :default => 10000000  # 10MB
+    config_param :max_total_size,     :integer, :default => 9800000  # 9.8MB
     config_param :format,             :string,  :default => 'json'
 
     unless method_defined?(:log)

--- a/test/plugin/test_out_gcloud_pubsub.rb
+++ b/test/plugin/test_out_gcloud_pubsub.rb
@@ -30,7 +30,7 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
       assert_equal('key-test', d.instance.key)
       assert_equal(false, d.instance.autocreate_topic)
       assert_equal(1000, d.instance.max_messages)
-      assert_equal(10000000, d.instance.max_total_size)
+      assert_equal(9800000, d.instance.max_total_size)
     end
 
     test '"topic" must be specified' do


### PR DESCRIPTION
For fixing below error.

```
2016-09-11 22:40:00 +0900 [warn]: fluent/output.rb:415:rescue in before_shutdown: before_shutdown failed error="3:The value for request_size is too large. You passed 10006011 in the request, but the maximum value is 10000000."
```
