### PR TITLE
Rescue acknowledge errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile.v0.12
+++ b/Gemfile.v0.12
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source 'https://rubygems.org'
 
 gem 'fluentd', '~> 0.12.0'
 

--- a/lib/fluent/plugin/gcloud_pubsub/client.rb
+++ b/lib/fluent/plugin/gcloud_pubsub/client.rb
@@ -37,11 +37,13 @@ module Fluent
       def pull(immediate, max)
         @client.pull immediate: immediate, max: max
       rescue Google::Cloud::UnavailableError, Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => ex
-        raise RetryableError.new "Google api returns error:#{ex.class.to_s} message:#{ex.to_s}"
+        raise RetryableError.new "Google pull api returns error:#{ex.class.to_s} message:#{ex.to_s}"
       end
 
       def acknowledge(messages)
         @client.acknowledge messages
+      rescue Google::Cloud::UnavailableError, Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => ex
+        raise RetryableError.new "Google acknowledge api returns error:#{ex.class.to_s} message:#{ex.to_s}"
       end
     end
   end


### PR DESCRIPTION
Input plugin can retry if acknowledge api raise 50x errors.
