### PR TITLE
Make retry to get topic/subscription when Pub/Sub API returns 50x code

### DIFF
--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "fluentd", [">= 0.10.58", "< 2"]
   gem.add_runtime_dependency "google-cloud-pubsub", "~> 0.22.0"
+  gem.add_runtime_dependency "retryable", "~> 2.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
This feature is useful for using `forest` plugin and file buffer.
Because forest cannot plant new plugin instance if pubsub plugin failed to start once.
