### PR TITLE
Added "status" method to the http rpc api.

### DIFF
--- a/lib/fluent/plugin/in_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/in_gcloud_pubsub.rb
@@ -92,15 +92,18 @@ module Fluent
       end
 
       def process(req, res)
+        ret = {'ok' => true}
         case req.path_info
         when '/stop'
           @plugin.stop_pull
         when '/start'
           @plugin.start_pull
+        when '/status'
+          ret['status'] = @plugin.status_of_pull
         else
           raise Error.new "Invalid path_info: #{req.path_info}"
         end
-        render_json(200, {'ok' => true})
+        render_json(200, ret)
       end
     end
 
@@ -157,6 +160,10 @@ module Fluent
     def start_pull
       @stop_pull = false
       log.info "start pull from subscription:#{@subscription}"
+    end
+
+    def status_of_pull
+      @stop_pull ? 'stopped' : 'started'
     end
 
     private

--- a/test/plugin/test_in_gcloud_pubsub.rb
+++ b/test/plugin/test_in_gcloud_pubsub.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'json'
 
 require_relative "../test_helper"
 
@@ -354,6 +355,27 @@ class GcloudPubSubInputTest < Test::Unit::TestCase
         assert_equal("test", tag)
         assert_equal({"foo" => "bar"}, record)
       end
+    end
+
+    test 'get status by http rpc when started' do
+      d = create_driver("#{CONFIG}\npull_interval 1.0\nenable_rpc true")
+      assert_equal(false, d.instance.instance_variable_get(:@stop_pull))
+
+      d.run {
+        res = http_get('/api/in_gcloud_pubsub/pull/status')
+        assert_equal({"ok" => true, "status" => "started"}, JSON.parse(res.body))
+      }
+    end
+
+    test 'get status by http rpc when stopped' do
+      d = create_driver("#{CONFIG}\npull_interval 1.0\nenable_rpc true")
+      d.instance.stop_pull
+      assert_equal(true, d.instance.instance_variable_get(:@stop_pull))
+
+      d.run {
+        res = http_get('/api/in_gcloud_pubsub/pull/status')
+        assert_equal({"ok" => true, "status" => "stopped"}, JSON.parse(res.body))
+      }
     end
   end
 end


### PR DESCRIPTION
Allow users to check current pull status via http rpc endpoint `/in_gcloud_pubsub/pull/status`.
This gives users an easier control of the plugin over http.

```sh
$ curl 'localhost:24680/api/in_gcloud_pubsub/pull/status'
{"ok": true, "status": "started"}
```

The `status` is either "started" or "stopped".

Ref: #15 