### PR TITLE
Fix max message size error

### DIFF
--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -24,7 +24,7 @@ module Fluent
     desc 'Publishing messages count per request to Cloud Pub/Sub.'
     config_param :max_messages,       :integer, :default => 1000
     desc 'Publishing messages bytesize per request to Cloud Pub/Sub.'
-    config_param :max_total_size,     :integer, :default => 9800000  # 9.8MB
+    config_param :max_total_size,     :integer, :default => 4000000  # 4MB
     desc 'Set output format.'
     config_param :format,             :string,  :default => 'json'
 

--- a/test/plugin/test_out_gcloud_pubsub.rb
+++ b/test/plugin/test_out_gcloud_pubsub.rb
@@ -30,7 +30,7 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
       assert_equal('key-test', d.instance.key)
       assert_equal(false, d.instance.autocreate_topic)
       assert_equal(1000, d.instance.max_messages)
-      assert_equal(9800000, d.instance.max_total_size)
+      assert_equal(4000000, d.instance.max_total_size)
     end
 
     test '"topic" must be specified' do


### PR DESCRIPTION
- #12 `Received message larger than max (21824326 vs. 4194304)` all the time
- This PR fixes it

## What's going wrong?

- gRPC introduced a request limit of 4MB (with version 1.0 I believe)
- Google cloud libraries recently started using gRPC internally for streaming, and the **same 4MB limit** started applying to PubSub as well. That's why we see `Received message larger than max (xxxx vs 4194304)` - note **4194304**
- The same problem can be referenced here: https://github.com/GoogleCloudPlatform/google-cloud-node/issues/2190
- Google fixed NodeJS/Java libraries, but has not fixed Ruby libraries yet (PubSub ruby support is in alpha)

But until then, this is a high priority bug for this plugin. Its not good to publish messages with default max_total_size of `9.8MB` *when we know for sure* that its going to fail in the receiver side. Its results in a non-working combination right from the very beginning. And worse still, the rejected/unacked messages keep circulating in loop (PubSub doesn't remove messages for 1 week), there by increasing back pressure.

Until Google fixes this on their side, its best to make this plugin do the right thing. To avoid slowdown, we could increase the default threads, what do you think?