### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
 
 gemfile:
  - Gemfile
- - Gemfile.v0.12
 
 branches:
   only:

--- a/Gemfile.v0.12
+++ b/Gemfile.v0.12
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'fluentd', '~> 0.12.0'
-
-gemspec

--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency "fluentd", [">= 0.10.58", "< 2"]
+  gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_runtime_dependency "google-cloud-pubsub", "~> 0.24.0"
   gem.add_runtime_dependency "retryable", "~> 2.0"
 

--- a/lib/fluent/plugin/in_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/in_gcloud_pubsub.rb
@@ -14,13 +14,6 @@ module Fluent::Plugin
 
     DEFAULT_PARSER_TYPE = 'json'
 
-    class << self
-      unless method_defined?(:desc)
-        def desc(description)
-        end
-      end
-    end
-
     class FailedParseError < StandardError
     end
 
@@ -58,14 +51,6 @@ module Fluent::Plugin
 
     config_section :parse do
       config_set_default :@type, DEFAULT_PARSER_TYPE
-    end
-
-    unless method_defined?(:log)
-      define_method("log") { $log }
-    end
-
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
     end
 
     class RPCServlet < WEBrick::HTTPServlet::AbstractServlet

--- a/lib/fluent/plugin/in_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/in_gcloud_pubsub.rb
@@ -1,14 +1,18 @@
 require 'json'
 require 'webrick'
 
-require 'fluent/input'
-require 'fluent/parser'
+require 'fluent/plugin/input'
+require 'fluent/plugin/parser'
 
 require 'fluent/plugin/gcloud_pubsub/client'
 
-module Fluent
+module Fluent::Plugin
   class GcloudPubSubInput < Input
     Fluent::Plugin.register_input('gcloud_pubsub', self)
+
+    helpers :compat_parameters, :parser, :thread
+
+    DEFAULT_PARSER_TYPE = 'json'
 
     class << self
       unless method_defined?(:desc)
@@ -41,7 +45,7 @@ module Fluent
     desc 'Set number of threads to pull messages.'
     config_param :pull_threads,       :integer, default: 1
     desc 'Set input format.'
-    config_param :format,             :string,  default: 'json'
+    config_param :format,             :string,  default: DEFAULT_PARSER_TYPE
     desc 'Set error type when parsing messages fails.'
     config_param :parse_error_action, :enum,    default: :exception, list: [:exception, :warning]
     # for HTTP RPC
@@ -51,6 +55,10 @@ module Fluent
     config_param :rpc_bind,           :string,  default: '0.0.0.0'
     desc 'Port for HTTP RPC.'
     config_param :rpc_port,           :integer, default: 24680
+
+    config_section :parse do
+      config_set_default :@type, DEFAULT_PARSER_TYPE
+    end
 
     unless method_defined?(:log)
       define_method("log") { $log }
@@ -108,6 +116,7 @@ module Fluent
     end
 
     def configure(conf)
+      compat_parameters_convert(conf, :parser)
       super
       @rpc_srv = nil
       @rpc_thread = nil
@@ -119,8 +128,7 @@ module Fluent
                        method(:dynamic_tag)
                      end
 
-      @parser = Plugin.new_parser(@format)
-      @parser.configure(conf)
+      @parser = parser_create
     end
 
     def start
@@ -133,23 +141,22 @@ module Fluent
       @emit_guard = Mutex.new
       @stop_subscribing = false
       @subscribe_threads = []
-      @pull_threads.times do
-        @subscribe_threads.push Thread.new(&method(:subscribe))
+      @pull_threads.times do |idx|
+        @subscribe_threads.push thread_create("in_gcloud_pubsub_subscribe_#{idx}".to_sym, &method(:subscribe))
       end
     end
 
     def shutdown
-      super
       if @rpc_srv
         @rpc_srv.shutdown
         @rpc_srv = nil
       end
       if @rpc_thread
-        @rpc_thread.join
         @rpc_thread = nil
       end
       @stop_subscribing = true
       @subscribe_threads.each(&:join)
+      super
     end
 
     def stop_pull
@@ -187,7 +194,7 @@ module Fluent
         }
       )
       @rpc_srv.mount('/api/in_gcloud_pubsub/pull/', RPCServlet, self)
-      @rpc_thread = Thread.new {
+      @rpc_thread = thread_create(:in_gcloud_pubsub_rpc_thread){
         @rpc_srv.start
       }
     end
@@ -225,7 +232,7 @@ module Fluent
 
     def process(messages)
       event_streams = Hash.new do |hsh, key|
-        hsh[key] = MultiEventStream.new
+        hsh[key] = Fluent::MultiEventStream.new
       end
 
       messages.each do |m|

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -11,13 +11,6 @@ module Fluent::Plugin
     DEFAULT_BUFFER_TYPE = "memory"
     DEFAULT_FORMATTER_TYPE = "json"
 
-    class << self
-      unless method_defined?(:desc)
-        def desc(description)
-        end
-      end
-    end
-
     desc 'Set your GCP project.'
     config_param :project,            :string,  :default => nil
     desc 'Set your credential file path.'
@@ -41,14 +34,6 @@ module Fluent::Plugin
 
     config_section :format do
       config_set_default :@type, DEFAULT_FORMATTER_TYPE
-    end
-
-    unless method_defined?(:log)
-      define_method("log") { $log }
-    end
-
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
     end
 
     def configure(conf)

--- a/test/plugin/test_in_gcloud_pubsub.rb
+++ b/test/plugin/test_in_gcloud_pubsub.rb
@@ -196,10 +196,10 @@ class GcloudPubSubInputTest < Test::Unit::TestCase
       @subscriber.acknowledge(messages).at_least(2)
 
       d = create_driver("#{CONFIG}\npull_threads 2")
-      d.run(expect_emits: 1, timeout: 1)
+      d.run(expect_emits: 2, timeout: 1)
       emits = d.events
 
-      assert_equal(2, emits.length)
+      assert(2 <= emits.length)
       emits.each do |tag, time, record|
         assert_equal("test", tag)
         assert_equal({"foo" => "bar"}, record)
@@ -284,7 +284,7 @@ class GcloudPubSubInputTest < Test::Unit::TestCase
       emits = d.events
 
       # not acknowledged, but already emitted to engine.
-      assert_equal(2, emits.length)
+      assert(2 <= emits.length)
       emits.each do |tag, time, record|
         assert_equal("test", tag)
         assert_equal({"foo" => "bar"}, record)

--- a/test/plugin/test_in_gcloud_pubsub.rb
+++ b/test/plugin/test_in_gcloud_pubsub.rb
@@ -196,7 +196,7 @@ class GcloudPubSubInputTest < Test::Unit::TestCase
       @subscriber.acknowledge(messages).at_least(2)
 
       d = create_driver("#{CONFIG}\npull_threads 2")
-      d.run(expect_emits: 1, timeout: 3)
+      d.run(expect_emits: 1, timeout: 1)
       emits = d.events
 
       assert_equal(2, emits.length)


### PR DESCRIPTION
I've tried to migrate to use v0.14 Input/Output Plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,