### PR TITLE
Add requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ This plugin is forked from https://github.com/mdoi/fluent-plugin-gcloud-pubsub
 - Add a pull style subscription to the topic
 - Download your credential (json) or [set scope on GCE instance](https://cloud.google.com/compute/docs/api/how-tos/authorization)
 
+## Requirements
+
+| fluent-plugin-gcloud-pubsub-custom | fluentd | ruby |
+|------------------------|---------|------|
+| >= 1.0.0 | >= v0.14.0 | >= 2.1 |
+|  < 1.0.0 | >= v0.12.0 | >= 1.9 |
+
 ## Installation
 
 Install by gem:


### PR DESCRIPTION
Sometimes Fluentd users report Fluentd version bumping upexpectedly.
We should announce about dependency changes at least in README.

Note that Fluentd v0.10 had been reached EOL.
So, I wrote order than v1.0.0 version require Fluentd v0.12 or later.