### PR TITLE
Bump up google-cloud-pubsub to v0.26.x

### DIFF
--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
-  gem.add_runtime_dependency "google-cloud-pubsub", "~> 0.24.0"
+  gem.add_runtime_dependency "google-cloud-pubsub", "~> 0.26.0"
   gem.add_runtime_dependency "retryable", "~> 2.0"
 
   gem.add_development_dependency "bundler"


### PR DESCRIPTION
`Project#topic` method argument `autocreate` was removed in google-cloud-pubsub v0.27.0 .
So I bump up google-cloud-pubsub to v0.26.x . And I will bump up it to v0.27.x later.