### PR TITLE
Remove Retryable gem

### DIFF
--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_runtime_dependency "google-cloud-pubsub", "~> 0.26.0"
-  gem.add_runtime_dependency "retryable", "~> 2.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"

--- a/lib/fluent/plugin/gcloud_pubsub/client.rb
+++ b/lib/fluent/plugin/gcloud_pubsub/client.rb
@@ -1,5 +1,4 @@
 require 'google/cloud/pubsub'
-require 'retryable'
 
 module Fluent
   module GcloudPubSub
@@ -9,14 +8,9 @@ module Fluent
     end
 
     class Publisher
-      RETRY_COUNT = 5
-      RETRYABLE_ERRORS = [Google::Cloud::UnavailableError, Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError]
-
       def initialize(project, key, topic_name, autocreate_topic)
-        Retryable.retryable(tries: RETRY_COUNT, on: RETRYABLE_ERRORS) do
-          pubsub = Google::Cloud::Pubsub.new project: project, keyfile: key
-          @client = pubsub.topic topic_name, autocreate: autocreate_topic
-        end
+        pubsub = Google::Cloud::Pubsub.new project: project, keyfile: key
+        @client = pubsub.topic topic_name, autocreate: autocreate_topic
         raise Error.new "topic:#{topic_name} does not exist." if @client.nil?
       end
 
@@ -32,15 +26,10 @@ module Fluent
     end
 
     class Subscriber
-      RETRY_COUNT = 5
-      RETRYABLE_ERRORS = [Google::Cloud::UnavailableError, Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError]
-
       def initialize(project, key, topic_name, subscription_name)
-        Retryable.retryable(tries: RETRY_COUNT, on: RETRYABLE_ERRORS) do
-          pubsub = Google::Cloud::Pubsub.new project: project, keyfile: key
-          topic = pubsub.topic topic_name
-          @client = topic.subscription subscription_name
-        end
+        pubsub = Google::Cloud::Pubsub.new project: project, keyfile: key
+        topic = pubsub.topic topic_name
+        @client = topic.subscription subscription_name
         raise Error.new "subscription:#{subscription_name} does not exist." if @client.nil?
       end
 

--- a/test/plugin/test_in_gcloud_pubsub.rb
+++ b/test/plugin/test_in_gcloud_pubsub.rb
@@ -177,7 +177,7 @@ class GcloudPubSubInputTest < Test::Unit::TestCase
     test 'simple' do
       messages = Array.new(1, DummyMessage.new)
       @subscriber.pull(immediate: true, max: 100).at_least(1) { messages }
-      @subscriber.acknowledge(messages).once
+      @subscriber.acknowledge(messages).at_least(1)
 
       d = create_driver
       d.run(expect_emits: 1, timeout: 3)
@@ -213,13 +213,13 @@ class GcloudPubSubInputTest < Test::Unit::TestCase
         DummyMessage.new
       ]
       @subscriber.pull(immediate: true, max: 100).at_least(1) { messages }
-      @subscriber.acknowledge(messages).once
+      @subscriber.acknowledge(messages).at_least(1)
 
       d = create_driver("#{CONFIG}\ntag_key test_tag_key")
       d.run(expect_emits: 1, timeout: 3)
       emits = d.events
 
-      assert_equal(3, emits.length)
+      assert(3 <= emits.length)
       # test tag
       assert_equal("tag1", emits[0][0])
       assert_equal("tag2", emits[1][0])

--- a/test/plugin/test_in_gcloud_pubsub.rb
+++ b/test/plugin/test_in_gcloud_pubsub.rb
@@ -108,7 +108,7 @@ class GcloudPubSubInputTest < Test::Unit::TestCase
     end
 
     test '50x error occurred on connecting to Pub/Sub' do
-      @topic_mock.subscription('subscription-test').times(5) do
+      @topic_mock.subscription('subscription-test').once do
         raise Google::Cloud::UnavailableError.new('TEST')
       end
 

--- a/test/plugin/test_out_gcloud_pubsub.rb
+++ b/test/plugin/test_out_gcloud_pubsub.rb
@@ -94,7 +94,7 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
     test '50x error occurred on connecting to Pub/Sub' do
       d = create_driver
 
-      @pubsub_mock.topic('topic-test', autocreate: false).times(5) do
+      @pubsub_mock.topic('topic-test', autocreate: false).once do
         raise Google::Cloud::UnavailableError.new('TEST')
       end
 


### PR DESCRIPTION
Its feature is for forest plugin, but the plugin shouldn't use on Fluentd v0.14. So I remove it.