### PR TITLE
Bump up google-cloud-pubsub to v0.27.x

### DIFF
--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
-  gem.add_runtime_dependency "google-cloud-pubsub", "~> 0.26.0"
+  gem.add_runtime_dependency "google-cloud-pubsub", "~> 0.27.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"

--- a/lib/fluent/plugin/gcloud_pubsub/client.rb
+++ b/lib/fluent/plugin/gcloud_pubsub/client.rb
@@ -10,8 +10,14 @@ module Fluent
     class Publisher
       def initialize(project, key, topic_name, autocreate_topic)
         pubsub = Google::Cloud::Pubsub.new project: project, keyfile: key
-        @client = pubsub.topic topic_name, autocreate: autocreate_topic
-        raise Error.new "topic:#{topic_name} does not exist." if @client.nil?
+        @client = pubsub.topic topic_name
+        if @client.nil?
+          if autocreate_topic
+            @client = pubsub.create_topic topic_name
+          else
+            raise Error.new "topic:#{topic_name} does not exist."
+          end
+        end
       end
 
       def publish(messages)

--- a/test/plugin/test_in_gcloud_pubsub.rb
+++ b/test/plugin/test_in_gcloud_pubsub.rb
@@ -277,7 +277,7 @@ class GcloudPubSubInputTest < Test::Unit::TestCase
     test 'retry if raised RetryableError on acknowledge' do
       messages = Array.new(1, DummyMessage.new)
       @subscriber.pull(immediate: true, max: 100).at_least(2) { messages }
-      @subscriber.acknowledge(messages).twice { raise Google::Cloud::UnavailableError.new('TEST') }
+      @subscriber.acknowledge(messages).at_least(2) { raise Google::Cloud::UnavailableError.new('TEST') }
 
       d = create_driver("#{CONFIG}\npull_interval 0.5")
       d.run(expect_emits: 2, timeout: 3)

--- a/test/plugin/test_out_gcloud_pubsub.rb
+++ b/test/plugin/test_out_gcloud_pubsub.rb
@@ -75,14 +75,15 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
         autocreate_topic true
       ])
 
-      @pubsub_mock.topic("topic-test", autocreate: true).once { @publisher }
+      @pubsub_mock.topic("topic-test").once { nil }
+      @pubsub_mock.create_topic("topic-test").once { @publisher }
       d.run
     end
 
     test '40x error occurred on connecting to Pub/Sub' do
       d = create_driver
 
-      @pubsub_mock.topic('topic-test', autocreate: false).once do
+      @pubsub_mock.topic('topic-test').once do
         raise Google::Cloud::NotFoundError.new('TEST')
       end
 
@@ -94,7 +95,7 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
     test '50x error occurred on connecting to Pub/Sub' do
       d = create_driver
 
-      @pubsub_mock.topic('topic-test', autocreate: false).once do
+      @pubsub_mock.topic('topic-test').once do
         raise Google::Cloud::UnavailableError.new('TEST')
       end
 
@@ -106,7 +107,7 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
     test 'topic is nil' do
       d = create_driver
 
-      @pubsub_mock.topic('topic-test', autocreate: false).once { nil }
+      @pubsub_mock.topic('topic-test').once { nil }
 
       assert_raise Fluent::GcloudPubSub::Error do
         d.run {}
@@ -117,7 +118,7 @@ class GcloudPubSubOutputTest < Test::Unit::TestCase
   sub_test_case 'publish' do
     setup do
       @publisher = mock!
-      @pubsub_mock = mock!.topic(anything, anything) { @publisher }
+      @pubsub_mock = mock!.topic(anything) { @publisher }
       stub(Google::Cloud::Pubsub).new { @pubsub_mock }
     end
 


### PR DESCRIPTION
`Project#topic` method argument `autocreate` was removed at v0.27.0.
So I add the feature that creates new topic if the topic doesn't exist.
