### PR TITLE
Dumps raw string to logs for errors

### DIFF
--- a/lib/fluent/plugin/in_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/in_gcloud_pubsub.rb
@@ -233,9 +233,9 @@ module Fluent::Plugin
           else
             case @parse_error_action
             when :exception
-              raise FailedParseError.new "pattern not match: #{line.inspect}"
+              raise FailedParseError.new "pattern not match: #{line}"
             else
-              log.warn 'pattern not match', record: line.inspect
+              log.warn 'pattern not match', record: line
             end
           end
         end


### PR DESCRIPTION
The error or exception logs for ParseErrors dumps the object with  this causes JSON logs to be double  escaped making debugging difficult. The log message should be a string which can be emitted directly. Its possible the object may not be a string when other parser are used but I am personally unsure how much of an impact that may have.
cc @stonith @methodmissing

