### PR TITLE
topic name is unnecessary for pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Use `gcloud_pubsub` input plugin.
   - Set your credential file path.
   - Running fluentd on GCP, you can use scope instead of specifying this.
   - You can also use environment variable such as `GCLOUD_KEYFILE`.
-- `topic` (required)
-  - Set topic name to pull.
+- `topic` (optional)
+  - Set topic name that the subscription belongs to.
 - `subscription` (required)
   - Set subscription name to pull.
 - `max_messages` (optional, default: `100`)

--- a/lib/fluent/plugin/gcloud_pubsub/client.rb
+++ b/lib/fluent/plugin/gcloud_pubsub/client.rb
@@ -59,8 +59,12 @@ module Fluent
     class Subscriber
       def initialize(project, key, topic_name, subscription_name)
         pubsub = Google::Cloud::Pubsub.new project_id: project, credentials: key
-        topic = pubsub.topic topic_name
-        @client = topic.subscription subscription_name
+        if topic_name.nil?
+          @client = pubsub.subscription subscription_name
+        else
+          topic = pubsub.topic topic_name
+          @client = topic.subscription subscription_name
+        end
         raise Error.new "subscription:#{subscription_name} does not exist." if @client.nil?
       end
 

--- a/lib/fluent/plugin/in_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/in_gcloud_pubsub.rb
@@ -26,7 +26,7 @@ module Fluent::Plugin
     desc 'Set your credential file path.'
     config_param :key,                :string,  default: nil
     desc 'Set topic name to pull.'
-    config_param :topic,              :string
+    config_param :topic,              :string,  default: nil
     desc 'Set subscription name to pull.'
     config_param :subscription,       :string
     desc 'Pulling messages by intervals of specified seconds.'


### PR DESCRIPTION
## Changes

Make `topic` parameter optional on input plugin

## Reason

1. We don't need to specify topic name since subscription names are unique under a project
2. Current logic requires `viewer` role not only on the target subscription but also on the target topic
    - Note: You can create subscriptions under topics which reside in another projects