### PR TITLE
Supported　td-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ $ gem install fluent-plugin-gcloud-pubsub-custom
 
 **Caution**
 
-This plugin doesn't work in [td-agent](http://docs.fluentd.org/articles/install-by-rpm).
-
 Please use in [Fluentd installed by gem](http://docs.fluentd.org/articles/install-by-gem).
 
 ## Configuration


### PR DESCRIPTION
The following URL was confirmed and corrected.
https://github.com/mia-0032/fluent-plugin-gcloud-pubsub-custom/issues/32

Please confirm whether it really supports.