### PR TITLE
Add Pub/Sub serivce endpoint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Use `gcloud_pubsub` output plugin.
   max_messages 1000
   max_total_size 9800000
   max_message_size 4000000
+  endpoint <Endpoint URL>
   <buffer>
     @type memory
     flush_interval 1s
@@ -95,7 +96,8 @@ Use `gcloud_pubsub` output plugin.
   - Messages exceeding `max_message_size` are not published because Pub/Sub clients cannot receive it.
 - `attribute_keys` (optional, default: `[]`)
   - Publishing the set fields as attributes.
-
+- `endpoint`(optional)
+  - Set Pub/Sub service endpoint. For more information, see [Service Endpoints](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#service_endpoints)
 ### Pull messages
 
 Use `gcloud_pubsub` input plugin.

--- a/lib/fluent/plugin/gcloud_pubsub/client.rb
+++ b/lib/fluent/plugin/gcloud_pubsub/client.rb
@@ -24,8 +24,8 @@ module Fluent
     end
 
     class Publisher
-      def initialize(project, key, autocreate_topic, dest_project)
-        @pubsub = Google::Cloud::Pubsub.new project_id: project, credentials: key
+      def initialize(project, key, autocreate_topic, dest_project, endpoint)
+        @pubsub = Google::Cloud::Pubsub.new project_id: project, credentials: key, endpoint: endpoint
         @autocreate_topic = autocreate_topic
         @dest_project = dest_project
         @topics = {}

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -31,6 +31,8 @@ module Fluent::Plugin
     config_param :max_message_size,   :integer, :default => 4000000  # 4MB
     desc 'Publishing the set field as an attribute'
     config_param :attribute_keys,     :array,   :default => []
+    desc 'Set service endpoint'
+    config_param :endpoint, :string, :default => nil
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -49,7 +51,7 @@ module Fluent::Plugin
 
     def start
       super
-      @publisher = Fluent::GcloudPubSub::Publisher.new @project, @key, @autocreate_topic, @dest_project
+      @publisher = Fluent::GcloudPubSub::Publisher.new @project, @key, @autocreate_topic, @dest_project, @endpoint
     end
 
     def format(tag, time, record)


### PR DESCRIPTION
This Pull Request setting allows you to send requests to a regional Pub/Sub endpoint.
https://cloud.google.com/pubsub/docs/reference/service_apis_overview#service_endpoints