### PR TITLE
Set default timeout to use in publish requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Use `gcloud_pubsub` output plugin.
   max_total_size 9800000
   max_message_size 4000000
   endpoint <Endpoint URL>
+  timeout 60
   <buffer>
     @type memory
     flush_interval 1s
@@ -100,6 +101,8 @@ Use `gcloud_pubsub` output plugin.
   - Set Pub/Sub service endpoint. For more information, see [Service Endpoints](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#service_endpoints)
 - `compression` (optional, default: `nil`)
   - If set to `gzip`, messages will be compressed with gzip.
+- `timeout` (optional)
+  - Set default timeout to use in publish requests.
 
 ### Pull messages
 

--- a/lib/fluent/plugin/gcloud_pubsub/client.rb
+++ b/lib/fluent/plugin/gcloud_pubsub/client.rb
@@ -24,8 +24,8 @@ module Fluent
     end
 
     class Publisher
-      def initialize(project, key, autocreate_topic, dest_project, endpoint)
-        @pubsub = Google::Cloud::Pubsub.new project_id: project, credentials: key, endpoint: endpoint
+      def initialize(project, key, autocreate_topic, dest_project, endpoint, timeout)
+        @pubsub = Google::Cloud::Pubsub.new project_id: project, credentials: key, endpoint: endpoint, timeout: timeout
         @autocreate_topic = autocreate_topic
         @dest_project = dest_project
         @topics = {}

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -37,6 +37,8 @@ module Fluent::Plugin
     config_param :endpoint, :string, :default => nil
     desc 'Compress messages'
     config_param :compression, :string, :default => nil
+    desc 'Set default timeout to use in publish requests'
+    config_param :timeout, :integer, :default => nil
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -60,7 +62,7 @@ module Fluent::Plugin
 
     def start
       super
-      @publisher = Fluent::GcloudPubSub::Publisher.new @project, @key, @autocreate_topic, @dest_project, @endpoint
+      @publisher = Fluent::GcloudPubSub::Publisher.new @project, @key, @autocreate_topic, @dest_project, @endpoint, @timeout
     end
 
     def format(tag, time, record)


### PR DESCRIPTION
Set default timeout to use in publish requests. 
https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-pubsub/lib/google/cloud/pubsub.rb#L109

https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-pubsub/lib/google/cloud/pubsub.rb#L130