### PR TITLE
add attribute key values params without deleting input message

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ Use `gcloud_pubsub` output plugin.
 - `max_message_size` (optional, default: `4000000` = `4MB`)
   - Messages exceeding `max_message_size` are not published because Pub/Sub clients cannot receive it.
 - `attribute_keys` (optional, default: `[]`)
-  - Publishing the set fields as attributes.
+  - Publishing the set fields as attributes generated from input message.
+- `attribute_key_values` (optional, default: `{}`)
+  - Publishing the set fields as attributes generated from input params
 - `endpoint`(optional)
   - Set Pub/Sub service endpoint. For more information, see [Service Endpoints](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#service_endpoints)
 - `compression` (optional, default: `nil`)

--- a/lib/fluent/plugin/out_gcloud_pubsub.rb
+++ b/lib/fluent/plugin/out_gcloud_pubsub.rb
@@ -31,8 +31,10 @@ module Fluent::Plugin
     config_param :max_total_size,     :integer, :default => 9800000  # 9.8MB
     desc 'Limit bytesize per message.'
     config_param :max_message_size,   :integer, :default => 4000000  # 4MB
-    desc 'Publishing the set field as an attribute'
+    desc 'Publishing the set field as an attribute created from input message'
     config_param :attribute_keys,     :array,   :default => []
+    desc 'Publishing the set field as an attribute created from input config params'
+    config_param :attribute_key_values,     :hash,   :default => {}
     desc 'Set service endpoint'
     config_param :endpoint, :string, :default => nil
     desc 'Compress messages'
@@ -68,6 +70,9 @@ module Fluent::Plugin
       attributes = {}
       @attribute_keys.each do |key|
         attributes[key] = record.delete(key)
+      end
+      @attribute_key_values.each do |key, value|
+        attributes[key] = value
       end
       [@compress.call(@formatter.format(tag, time, record)), attributes].to_msgpack
     end


### PR DESCRIPTION
add `attribute_key_values` params. this option define attribute key value pair from fluent conf without deleting input message.
existing `attribute_keys`  params delete input message [1] so need to define different columns and some value is not in input message. by using `attribute_key_values` we can solve this issue and could be more flexible

I am using attribution key under the reason

-  Cloud Pub/Sub subscription filter  based on attribution
some product want to use spesific table data so use Cloud Pub/Sub subscription filter  based on attribution. I am thinking to use database and table name filter
https://cloud.google.com/pubsub/docs/filtering

- Masking secret data in Dataflow used by attribution secret_columns value


[1] attribute_keys
https://github.com/mia-0032/fluent-plugin-gcloud-pubsub-custom/pull/77/files#diff-70c496844a78a4a86983bbec7f1ea30ddb89d1c55ce9efa06f139169ece392c3R72

example
```
attributes = {}
attribute_key_values  = {database: "database_a", table: "table_a", "secret_columns": ["column_a", "column_b"]}
attribute_key_values.each do |key, value|
  attributes[key] = value
end
puts attributes
{:database=>"database_a", :table=>"table_a", :secret_columns=>["column_a", "column_b"]}
```
